### PR TITLE
add auto-otp generation using oathtool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,9 @@ Usage
 .. code:: bash
 
    usage: mfa-aws [options]
-    
+
    updates aws credentials file with temporary sts credentials obtained with mfa
-    
+
    optional arguments:
      -h, --help            show this help message and exit
      -d, --debug           Enable debug
@@ -33,7 +33,7 @@ Before
    [default]
    aws_access_key_id = ASIADSJFKDSF3242
    aws_secret_access_key = FDSFSDKJFd/fdsfSDFSFfDSF4837fdDSFHDKSFsd0D
-    
+
    [other-account-default]
    aws_access_key_id = ASIADSGFDDFG3897
    aws_secret_access_key = DFGKSJGSDKJGSDKJ4636//43643KJ353KJH/KFDFSDFS/DLKDKSFsd0D
@@ -45,11 +45,12 @@ Before
    [profile default]
    mfa_serial = arn:aws:iam::111111111111:mfa/username
    dest_profile = default-mfa
-    
+
    [profile other-account]
    mfa_serial = arn:aws:iam::999999999999:mfa/username
    dest_profile = other-account-mfa
    source_profile = other-account-default
+   mfa_secret = 4HIANG4VIUY5SUVL22L2QDRX7Q7EQAUUKZC5QTWNHKSEQDEW2TOFZUMIQROTFPU3
 
 Run
 ~~~
@@ -58,9 +59,10 @@ Run
 
    MBP-USERNAME:~ username$ mfa-aws
    token code for arn:aws:iam::111111111111:mfa/username: 111111
+   Updated credentials for default-mfa
    MBP-USERNAME:~ username$
    MBP-USERNAME:~ username$ mfa-aws -p other-account
-   token code for arn:aws:iam::999999999999:mfa/username: 999999
+   Updated credentials for other-account-mfa
    MBP-USERNAME:~ username$
 
 After
@@ -75,16 +77,16 @@ After
    [default]
    aws_access_key_id = ASIADSJFKDSF3242
    aws_secret_access_key = FDSFSDKJFd/fdsfSDFSFfDSF4837fdDSFHDKSFsd0D
-    
+
    [other-account-default]
    aws_access_key_id = ASIADSGFDDFG3897
    aws_secret_access_key = DFGKSJGSDKJGSDKJ4636//43643KJ353KJH/KFDFSDFS/DLKDKSFsd0D
-    
+
    [default-mfa]
    aws_access_key_id = ASIADSJFKDSF3242
    aws_secret_access_key = FDSFSDKJFd/fdsfSDFSFfDSF4837fdDSFHDKSFsd0D
    aws_session_token = RIKJSFSAFJAS128753718965/352523//35jfhdssdDSJFKRIKJSFSAFJAS128753718965/352523//35jfhdssdDSJFKRIKJSFSAFJAS128753718965/352523//35jfhdssdDSJFK
-    
+
    [other-account-mfa]
    aws_access_key_id = ASIADSGFDDFG3897
    aws_secret_access_key = DFGKSJGSDKJGSDKJ4636//43643KJ353KJH/KFDFSDFS/DLKDKSFsd0D

--- a/bin/mfa-aws
+++ b/bin/mfa-aws
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import base64, binascii
 import boto3
 from botocore.exceptions import ClientError
 import argparse
@@ -7,6 +8,7 @@ import sys
 import shlex
 import re
 import os
+import oathtool
 import signal
 import configparser
 
@@ -56,6 +58,15 @@ def validate_token_code(arg_string):
     if not re.match(r"\d{6}", arg_string):
         raise ValueError(
                 "token_code must be 6 digits: '{0}'.".format(arg_string))
+    return arg_string
+
+
+def validate_token_secret(arg_string):
+    try:
+        base64.b32decode(arg_string)
+    except binascii.Error as e:
+        raise ValueError(
+                f"mfa_secret is not a valid base32 string ({str(e)})")
     return arg_string
 
 
@@ -159,8 +170,12 @@ def get_credential_dict(source_profile, mfa_serial, region, token_code, mfa_dura
     return get_session_token_response.get('Credentials')
 
 
-def get_token_code_from_user(mfa_serial):
-    token_code = validate_token_code(input("token code for {0}: ".format(mfa_serial)))
+def get_token_code_from_user(mfa_profile):
+    if "mfa_secret" in mfa_profile.keys():
+        validate_token_secret(mfa_profile["mfa_secret"])
+        token_code = oathtool.generate_otp(mfa_profile["mfa_secret"])
+    else:
+        token_code = validate_token_code(input("token code for {0}: ".format(mfa_profile["mfa_serial"])))
     return token_code
 
 
@@ -173,16 +188,16 @@ def main():
     # Parse Args and read config
     options = parse_args()
     config = read_config(options.config_file)
-    token_code = get_token_code_from_user(config[options.profile]["mfa_serial"])
+    token_code = get_token_code_from_user(config[options.profile])
     credential_dict = get_credential_dict(source_profile=config[options.profile].get("source_profile", options.profile),
                               mfa_serial=config[options.profile]["mfa_serial"],
                               mfa_duration=config[options.profile].get("mfa_duration", DEFAULT_MFA_DURATION),
                               region=config[options.profile].get("region", None), token_code=token_code)
     update_config(dest_profile=config[options.profile]["dest_profile"],
                         credential_dict=credential_dict, aws_credentials_file=AWS_CREDENTIALS_FILE_PATH)
+    print("Updated "+config[options.profile]["dest_profile"])
 
 if __name__ == '__main__':
     signal.signal(signal.SIGINT, signal_handler)
     main()
     sys.exit(0)
-

--- a/config/mfa-config
+++ b/config/mfa-config
@@ -8,3 +8,4 @@ source_profile = default
 mfa_serial = arn:aws:iam::999999999999:mfa/username
 dest_profile = other-account-mfa
 source_profile = other-account-default
+mfa_secret = 4HIANG4VIUY5SUVL22L2QDRX7Q7EQAUUKZC5QTWNHKSEQDEW2TOFZUMIQROTFPU3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ def find_version(*file_paths):
 
 install_requires = [
   'botocore',
-  'boto3'
+  'boto3',
+  'oathtool'
 ]
 
 


### PR DESCRIPTION
I thaught it would be useful to be able to auto-generate the OTP based on its secret. Yes, it somehow violates the idea of MFA. On the other hand it enables non-interactive use of MFA protected accounts in cases where you have no control over the MFA settings but need to build a non-interactive workflow. A user can still decide for himself what's more important to him.